### PR TITLE
Dt 2738 add role count to user summary

### DIFF
--- a/integration-tests/integration/dpsuser.search-with-filter.spec.js
+++ b/integration-tests/integration/dpsuser.search-with-filter.spec.js
@@ -114,13 +114,16 @@ context('DPS search with filter user functionality', () => {
     searchWithFilter.rows().should('have.length', 3)
     searchWithFilter.getPaginationResults().should('contain.text', 'Showing 1 to 3 of 3 results')
   })
-  it('will shows user details in the results', () => {
-    const searchWithFilter = goToSearchWithFilterPage({ totalElements: 1 })
-    searchWithFilter.rows().should('have.length', 1)
+  it('will show user details in the results', () => {
+    const searchWithFilter = goToSearchWithFilterPage({ totalElements: 3 })
+    searchWithFilter.rows().should('have.length', 3)
     searchWithFilter.rows().eq(0).should('include.text', 'Itag\u00a0User0')
     searchWithFilter.rows().eq(0).should('include.text', 'dps-user@justice.gov.uk')
     searchWithFilter.rows().eq(0).should('include.text', 'Active')
     searchWithFilter.rows().eq(0).should('include.text', 'Brixton (HMP)')
+    searchWithFilter.rows().eq(0).should('include.text', 'No DPS roles')
+    searchWithFilter.rows().eq(1).should('include.text', '1 DPS role')
+    searchWithFilter.rows().eq(2).should('include.text', '2 DPS roles')
   })
   it('will have a link to maintain the user', () => {
     cy.task('stubDpsUserDetails')

--- a/integration-tests/integration/dpsuser.search-with-filter.spec.js
+++ b/integration-tests/integration/dpsuser.search-with-filter.spec.js
@@ -114,6 +114,14 @@ context('DPS search with filter user functionality', () => {
     searchWithFilter.rows().should('have.length', 3)
     searchWithFilter.getPaginationResults().should('contain.text', 'Showing 1 to 3 of 3 results')
   })
+  it('will shows user details in the results', () => {
+    const searchWithFilter = goToSearchWithFilterPage({ totalElements: 1 })
+    searchWithFilter.rows().should('have.length', 1)
+    searchWithFilter.rows().eq(0).should('include.text', 'Itag\u00a0User0')
+    searchWithFilter.rows().eq(0).should('include.text', 'dps-user@justice.gov.uk')
+    searchWithFilter.rows().eq(0).should('include.text', 'Active')
+    searchWithFilter.rows().eq(0).should('include.text', 'Brixton (HMP)')
+  })
   it('will have a link to maintain the user', () => {
     cy.task('stubDpsUserDetails')
 

--- a/integration-tests/mockApis/nomisusersandroles.js
+++ b/integration-tests/mockApis/nomisusersandroles.js
@@ -10,6 +10,7 @@ const replicateUser = (times) =>
       id: 'BXI',
       name: 'Brixton (HMP)',
     },
+    dpsRoleCount: i,
   }))
 
 module.exports = {

--- a/views/searchWithFilter.njk
+++ b/views/searchWithFilter.njk
@@ -165,18 +165,31 @@
                       </div>
                       <div class="govuk-grid-row govuk-!-margin-bottom-2">
                         <div class="govuk-grid-column-full">
-                        <span class="govuk-visually-hidden">Status</span>
-                          {{ govukTag({
-                            text: "Inactive",
-                            classes: "govuk-tag--pink"
-                          }) if not u.active }}
-                          {{ govukTag({
-                            text: "Active",
-                            classes: "govuk-tag--green"
-                          }) if u.active }}
-                          {% if u.activeCaseload %}
-                          <span>{{u.activeCaseload.name}}</span>
-                          {% endif %}
+                          <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-one-half">
+                              <span class="govuk-visually-hidden">Status</span>
+                                {{ govukTag({
+                                  text: "Inactive",
+                                  classes: "govuk-tag--pink"
+                                }) if not u.active }}
+                                {{ govukTag({
+                                  text: "Active",
+                                  classes: "govuk-tag--green"
+                                }) if u.active }}
+                                {% if u.activeCaseload %}
+                                  <span>{{u.activeCaseload.name}}</span>
+                                {% endif %}
+                            </div>
+                            <div class="govuk-grid-column-one-half pull-right">
+                              {% if u.dpsRoleCount == 0 %}
+                              <span>No DPS roles</span>
+                              {% elif u.dpsRoleCount == 1 %}
+                              <span>{{u.dpsRoleCount}} DPS role</span>
+                              {% else %}
+                              <span>{{u.dpsRoleCount}} DPS roles</span>
+                              {% endif %}
+                            </div>
+                          </div>
                       </div>
                       </div>
                     </div>


### PR DESCRIPTION
Add a number DPS role assigned to user on the search results page

<img width="855" alt="Screenshot 2021-10-15 at 15 51 27" src="https://user-images.githubusercontent.com/22792098/137507594-33a00fb3-1eb1-45d2-96f9-cb0a42dafc0c.png">
