### PR TITLE
DT-2589 Move environment Phase up to header and a responsive feedback banner

### DIFF
--- a/backend/phaseNameSetup.js
+++ b/backend/phaseNameSetup.js
@@ -4,6 +4,7 @@ const preprodText = 'This test version of Manage user accounts contains real dat
 
 module.exports = (app, config) => {
   app.locals.phaseName = config.phaseName
+  app.locals.phaseNameShort = config.phaseName === 'PRE-PRODUCTION' ? 'PRE-PROD' : config.phaseName
   app.locals.phaseNameColour = config.phaseName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   app.locals.phaseNameText = config.phaseName === 'PRE-PRODUCTION' ? preprodText : ''
 }

--- a/backend/phaseNameSetup.test.js
+++ b/backend/phaseNameSetup.test.js
@@ -1,0 +1,34 @@
+const phaseNameSetup = require('./phaseNameSetup')
+
+describe('phaseNameSetup', () => {
+  it('will have a short phase version and colour for preproduction', () => {
+    const app = {
+      locals: {},
+    }
+    phaseNameSetup(app, { phaseName: 'PRE-PRODUCTION' })
+
+    expect(app.locals.phaseName).toEqual('PRE-PRODUCTION')
+    expect(app.locals.phaseNameShort).toEqual('PRE-PROD')
+    expect(app.locals.phaseNameColour).toEqual('govuk-tag--green')
+  })
+  it('will have a same short phase version and no colour for dev', () => {
+    const app = {
+      locals: {},
+    }
+    phaseNameSetup(app, { phaseName: 'DEV' })
+
+    expect(app.locals.phaseName).toEqual('DEV')
+    expect(app.locals.phaseNameShort).toEqual('DEV')
+    expect(app.locals.phaseNameColour).toEqual('')
+  })
+  it('will have a nothing when no phase supplied', () => {
+    const app = {
+      locals: {},
+    }
+    phaseNameSetup(app, { phaseName: '' })
+
+    expect(app.locals.phaseName).toEqual('')
+    expect(app.locals.phaseNameShort).toEqual('')
+    expect(app.locals.phaseNameColour).toEqual('')
+  })
+})

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -37,6 +37,20 @@
         display: inline-block;
       }
     }
+    &__phase-long {
+      display: none;
+      @include govuk-responsive-margin(3, 'left');
+      @include govuk-media-query($from: desktop) {
+        display: inline-block;
+      }
+    }
+    &__phase-short {
+      display: inline-block;
+      @include govuk-responsive-margin(3, 'left');
+      @include govuk-media-query($from: desktop) {
+        display: none;
+      }
+    }
   }
 
   &__link {
@@ -118,18 +132,22 @@
   @include govuk-width-container;
   @include govuk-responsive-margin(3, 'bottom');
   @include govuk-responsive-padding(3, 'top');
-  @include govuk-responsive-padding(3, 'bottom');
-  width: 100%;
   display: flex;
+  justify-content: space-between;
   flex-wrap: wrap;
   border-bottom: 1px solid $govuk-border-colour;
 
   &__location {
+    @include govuk-responsive-padding(3, 'bottom');
     @include govuk-font($size: 19, $weight: 'bold');
-    @include govuk-responsive-margin(3, 'right');
+
+    &__name {
+      @include govuk-responsive-margin(2, 'right');
+    }
   }
 
   &__feedback {
+    @include govuk-responsive-padding(3, 'bottom');
     @include govuk-font($size: 19, $weight: 'normal');
     @include govuk-responsive-margin(3, 'right');
   }
@@ -140,6 +158,11 @@
     @include govuk-font($size: 19, $weight: 'normal');
   }
 
+  .app-phase-banner {
+    border-bottom: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
   @media print {
     display: none;
   }

--- a/views/partials/header.njk
+++ b/views/partials/header.njk
@@ -13,6 +13,20 @@
       <a class="dps-header__link dps-header__title__organisation-name" href="/">HMPPS</a>
 
       <a class="dps-header__link dps-header__title__service-name" href="/">Digital Services</a>
+      {% if phaseName %}
+       <span class="dps-header__title__phase-long">
+        {{ govukTag({
+          text: phaseName,
+          classes: 'govuk-!-margin-right-1 ' + phaseNameColour
+        }) }}
+        </span>
+       <span class="dps-header__title__phase-short">
+        {{ govukTag({
+          text: phaseNameShort,
+          classes: 'govuk-!-margin-right-1 ' + phaseNameColour
+        }) }}
+        </span>
+      {% endif %}
     </div>
 
     <nav aria-label="Account navigation">
@@ -32,25 +46,23 @@
   </div>
 </header>
 <div class="location-bar">
-  {% if feedbackUrl %}
-  <span class="location-bar__feedback">
-    {{ govukTag({
-    text: "Feedback",
-    classes: 'govuk-!-margin-right-1 '
-  }) }}
-
-  This is a new service – your <a class="govuk-link" target="feedback" href="{{ feedbackUrl }}">feedback</a> will help us to improve it.</span>
-  {% endif %}
-  <span class="location-bar__location" data-qa="active-location">
-    {% if phaseName and not feedbackUrl %}
-      {{ govukTag({
-        text: phaseName,
-        classes: 'govuk-!-margin-right-1 ' + phaseNameColour
+    {% if feedbackUrl %}
+    <div class="location-bar__feedback">
+      {{ govukPhaseBanner({
+        classes: "app-phase-banner",
+        tag: {
+          text: "Feedback"
+        },
+        html: 'Provide <a class="govuk-link" target="feedback" href="' + feedbackUrl + '">feedback</a> to help us improve this page.'
       }) }}
+    </div>
     {% endif %}
-    {{ user.activeCaseLoad.name }}
-  </span>
-  {% if user.allCaseloads.length > 1 %}
-    <a class="location-bar__link" href="{{ dpsUrl }}/change-caseload" data-qa="change-location-link">Change location</a>
-  {% endif %}
+  <div class="location-bar__location" >
+    <span class="location-bar__location__name"  data-qa="active-location">
+      {{ user.activeCaseLoad.name }}
+    </span>
+    {% if user.allCaseloads.length > 1 %}
+      <a class="location-bar__link" href="{{ dpsUrl }}/change-caseload" data-qa="change-location-link">Change location</a>
+    {% endif %}
+  </div>
 </div>


### PR DESCRIPTION
Desktop View
![Screenshot 2021-11-09 at 17 59 30](https://user-images.githubusercontent.com/22792098/140979117-34426b27-b1a1-40ed-9aa9-fca26c4af414.png)

Smaller View with Feedback dropping to next line
![Screenshot 2021-11-09 at 17 59 50](https://user-images.githubusercontent.com/22792098/140979179-fcb56374-acc0-485e-802c-f86016028a55.png)

Mobile View with environment oases name shortened
<img width="500" alt="Screenshot 2021-11-09 at 18 00 30" src="https://user-images.githubusercontent.com/22792098/140979236-ae4431b6-d6d1-4e06-857a-3b2c91fda0cc.png">

Pages without feedback survey more or less unchanged
![Screenshot 2021-11-09 at 18 00 46](https://user-images.githubusercontent.com/22792098/140979288-ab2de814-4303-472a-a5e2-a248da44d956.png)


