### PR TITLE
HAAR-1270: display relevant validation msg when adding excluded email domain and prevent double clicking submit button

### DIFF
--- a/backend/controllers/addEmailDomain.js
+++ b/backend/controllers/addEmailDomain.js
@@ -32,10 +32,7 @@ const createEmailDomainFactory = (createEmailDomainApi, createEmailDomainUrl, li
         res.redirect('/email-domains')
       } catch (err) {
         if (err.status === 409 && err.response && err.response.body) {
-          let errorUserMessage = err.response.body.userMessage
-          errorUserMessage = errorUserMessage.slice(errorUserMessage.lastIndexOf(':') + 1)
-          errorUserMessage = errorUserMessage.charAt(1).toUpperCase() + errorUserMessage.slice(2)
-          const domainError = [{ href: '#domainName', text: errorUserMessage }]
+          const domainError = [{ href: '#domainName', text: err.response.body.userMessage }]
           stashStateAndRedirectToIndex(req, res, domainError, [domain])
         } else {
           throw err

--- a/backend/controllers/addEmailDomain.js
+++ b/backend/controllers/addEmailDomain.js
@@ -32,7 +32,10 @@ const createEmailDomainFactory = (createEmailDomainApi, createEmailDomainUrl, li
         res.redirect('/email-domains')
       } catch (err) {
         if (err.status === 409 && err.response && err.response.body) {
-          const domainError = [{ href: '#domainName', text: 'Domain name already exists' }]
+          let errorUserMessage = err.response.body.userMessage
+          errorUserMessage = errorUserMessage.slice(errorUserMessage.lastIndexOf(':') + 1)
+          errorUserMessage = errorUserMessage.charAt(1).toUpperCase() + errorUserMessage.slice(2)
+          const domainError = [{ href: '#domainName', text: errorUserMessage }]
           stashStateAndRedirectToIndex(req, res, domainError, [domain])
         } else {
           throw err

--- a/backend/controllers/addEmailDomain.test.js
+++ b/backend/controllers/addEmailDomain.test.js
@@ -79,7 +79,7 @@ describe('create email domain factory', () => {
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Some text : Domain already present in allowed list' } },
+        response: { body: { userMessage: 'Domain EXISTINGDOMAIN is already present in allowed list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -94,7 +94,7 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain already present in allowed list' },
+        { href: '#domainName', text: 'Domain EXISTINGDOMAIN is already present in allowed list' },
       ])
     })
 
@@ -104,7 +104,7 @@ describe('create email domain factory', () => {
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Some text : Domain present in excluded list' } },
+        response: { body: { userMessage: 'Domain EXCLUDEDDOMAIN is present in excluded list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -119,7 +119,7 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain present in excluded list' },
+        { href: '#domainName', text: 'Domain EXCLUDEDDOMAIN is present in excluded list' },
       ])
     })
   })

--- a/backend/controllers/addEmailDomain.test.js
+++ b/backend/controllers/addEmailDomain.test.js
@@ -73,13 +73,13 @@ describe('create email domain factory', () => {
       ])
     })
 
-    it('should fail gracefully if Domain already present in allowed list error is triggered', async () => {
+    it('should fail gracefully if Domain already present in the allowed list error is triggered', async () => {
       const redirect = jest.fn()
       const locals = jest.fn()
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Domain EXISTINGDOMAIN is already present in allowed list' } },
+        response: { body: { userMessage: 'Domain EXISTINGDOMAIN is already present in the allowed list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -94,7 +94,7 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain EXISTINGDOMAIN is already present in allowed list' },
+        { href: '#domainName', text: 'Domain EXISTINGDOMAIN is already present in the allowed list' },
       ])
     })
 
@@ -104,7 +104,7 @@ describe('create email domain factory', () => {
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Domain EXCLUDEDDOMAIN is present in excluded list' } },
+        response: { body: { userMessage: 'Domain EXCLUDEDDOMAIN is present in the excluded list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -119,7 +119,7 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain EXCLUDEDDOMAIN is present in excluded list' },
+        { href: '#domainName', text: 'Domain EXCLUDEDDOMAIN is present in the excluded list' },
       ])
     })
   })

--- a/backend/controllers/addEmailDomain.test.js
+++ b/backend/controllers/addEmailDomain.test.js
@@ -73,13 +73,13 @@ describe('create email domain factory', () => {
       ])
     })
 
-    it('should fail gracefully if Domain name already exists error is triggered', async () => {
+    it('should fail gracefully if Domain already present in allowed list error is triggered', async () => {
       const redirect = jest.fn()
       const locals = jest.fn()
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { error_description: 'Domain name already exists' } },
+        response: { body: { userMessage: 'Some text : Domain already present in allowed list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -94,7 +94,32 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain name already exists' },
+        { href: '#domainName', text: 'Domain already present in allowed list' },
+      ])
+    })
+
+    it('should fail gracefully if Domain present in excluded list error is triggered', async () => {
+      const redirect = jest.fn()
+      const locals = jest.fn()
+      const error = {
+        ...new Error('This failed'),
+        status: 409,
+        response: { body: { userMessage: 'Some text : Domain present in excluded list' } },
+      }
+
+      createEmailDomainApi.mockRejectedValue(error)
+      const req = {
+        body: {
+          domainName: 'EXCLUDEDDOMAIN',
+          domainDescription: 'EXCLUDED DOMAIN DESCRIPTION',
+        },
+        flash: jest.fn(),
+        originalUrl: '/email-domains',
+      }
+      await emailDomainFactory.createEmailDomain(req, { locals, redirect })
+      expect(redirect).toBeCalledWith('/email-domains')
+      expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
+        { href: '#domainName', text: 'Domain present in excluded list' },
       ])
     })
   })

--- a/backend/controllers/addEmailDomain.test.js
+++ b/backend/controllers/addEmailDomain.test.js
@@ -73,13 +73,13 @@ describe('create email domain factory', () => {
       ])
     })
 
-    it('should fail gracefully if Domain already present in the allowed list error is triggered', async () => {
+    it('should fail gracefully if Email Domain already present in the allowed list error is triggered', async () => {
       const redirect = jest.fn()
       const locals = jest.fn()
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Domain EXISTINGDOMAIN is already present in the allowed list' } },
+        response: { body: { userMessage: 'Email domain EXISTINGDOMAIN is already present in the allowed list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -94,17 +94,17 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain EXISTINGDOMAIN is already present in the allowed list' },
+        { href: '#domainName', text: 'Email domain EXISTINGDOMAIN is already present in the allowed list' },
       ])
     })
 
-    it('should fail gracefully if Domain present in excluded list error is triggered', async () => {
+    it('should fail gracefully if Email domain is present in excluded list error is triggered', async () => {
       const redirect = jest.fn()
       const locals = jest.fn()
       const error = {
         ...new Error('This failed'),
         status: 409,
-        response: { body: { userMessage: 'Domain EXCLUDEDDOMAIN is present in the excluded list' } },
+        response: { body: { userMessage: 'Email domain EXCLUDEDDOMAIN is present in the excluded list' } },
       }
 
       createEmailDomainApi.mockRejectedValue(error)
@@ -119,7 +119,7 @@ describe('create email domain factory', () => {
       await emailDomainFactory.createEmailDomain(req, { locals, redirect })
       expect(redirect).toBeCalledWith('/email-domains')
       expect(req.flash).toBeCalledWith('createEmailDomainErrors', [
-        { href: '#domainName', text: 'Domain EXCLUDEDDOMAIN is present in the excluded list' },
+        { href: '#domainName', text: 'Email domain EXCLUDEDDOMAIN is present in the excluded list' },
       ])
     })
   })

--- a/views/createEmailDomain.njk
+++ b/views/createEmailDomain.njk
@@ -53,6 +53,7 @@
 
         {{ govukButton({
           text: "Add Email Domain",
+          preventDoubleClick: true,
           type: "submit",
           classes: "govuk-!-margin-right-1",
           attributes: { "data-qa": "create-button" }

--- a/views/deleteEmailDomain.njk
+++ b/views/deleteEmailDomain.njk
@@ -40,6 +40,7 @@
         {% if hasManageEmailDomains %}
           {{ govukButton({
           text: "Delete Email Domain",
+          preventDoubleClick: true,
           type: "submit",
           classes: "govuk-button--warning",
           attributes: { "data-qa": "delete-domain-button" }


### PR DESCRIPTION
Display relevant validation msg when user attempts to add an excluded email domain and also prevent double clicking submit button on the create email domain screen.