### PR TITLE
HAAR-1647: Modsec rule (942430) matching too many special chars

### DIFF
--- a/helm_deploy/hmpps-manage-users/values.yaml
+++ b/helm_deploy/hmpps-manage-users/values.yaml
@@ -31,6 +31,7 @@ generic-service:
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateTargetById 942100 "!ARGS"  # disable libinjection testing on request args. to disable all SQLi testing, modify rules in the range 942100-942999
+      SecRuleUpdateTargetById 942430 "!ARGS:returnTo"
       SecAction \
         "id:900000,\
          phase:1,\


### PR DESCRIPTION
Added exclusion. Modsec rule (942430) matching too many special chars in the returnTo param.