### PR TITLE
Refactor oauthApi and tests in TypeScript

### DIFF
--- a/backend/api/oauthApi.test.ts
+++ b/backend/api/oauthApi.test.ts
@@ -1,13 +1,16 @@
 /** @type {any} */
-const nock = require('nock')
-const { oauthApiFactory } = require('./oauthApi')
+import nock from 'nock'
+import { oauthApiFactory } from './oauthApi'
 
 const clientId = 'clientId'
 const url = 'http://localhost'
 const clientSecret = 'clientSecret'
 
-const client = {}
-const oauthApi = oauthApiFactory(client, { url, clientId, clientSecret })
+const oauthApi = oauthApiFactory({
+  url,
+  apiClientId: clientId,
+  apiClientSecret: clientSecret,
+})
 const mock = nock(url, { reqheaders: { 'Content-Type': 'application/x-www-form-urlencoded' } })
 
 describe('oauthApi tests', () => {

--- a/backend/api/oauthApi.ts
+++ b/backend/api/oauthApi.ts
@@ -1,38 +1,49 @@
+import axios, { AxiosError, AxiosInstance } from 'axios'
+import querystring from 'querystring'
+import logger from '../../logger'
+import errorStatusCode from '../error-status-code'
+
 /** @type {any} */
-const axios = require('axios')
-const querystring = require('querystring')
-const logger = require('../log')
-const errorStatusCode = require('../error-status-code')
+export const AuthClientErrorName = 'AuthClientError'
+export const AuthClientError = (message: string) => ({ name: AuthClientErrorName, message, stack: new Error().stack })
 
-const AuthClientErrorName = 'AuthClientError'
-const AuthClientError = (message) => ({ name: AuthClientErrorName, message, stack: new Error().stack })
+export const apiClientCredentials = (clientId: string, clientSecret: string) =>
+  Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
 
-const apiClientCredentials = (clientId, clientSecret) => Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+export interface OAuthApi {
+  refresh: (refreshToken: string) => Promise<{ access_token: string; refresh_token: string }>
+  oauthAxios: AxiosInstance
+}
+
+export interface OAuthApiFactoryParams {
+  apiClientId: string
+  apiClientSecret: string
+  url: string
+}
 
 /**
  * Return an oauthApi built using the supplied configuration.
- * @param client
  * @param {object} params
- * @param {string} params.clientId
- * @param {string} params.clientSecret
- * @param {string} params.url
  * @returns a configured oauthApi instance
  */
-const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
-  const oauthAxios = axios.create({
-    baseURL: `${url}/oauth/token`,
+export const oauthApiFactory = (params: OAuthApiFactoryParams): OAuthApi => {
+  const oauthAxios: AxiosInstance = axios.create({
+    baseURL: `${params.url}/oauth/token`,
     method: 'post',
     timeout: 30000,
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      authorization: `Basic ${apiClientCredentials(clientId, clientSecret)}`,
+      authorization: `Basic ${apiClientCredentials(params.apiClientId, params.apiClientSecret)}`,
     },
   })
 
   // eslint-disable-next-line camelcase
-  const parseOauthTokens = ({ access_token, refresh_token }) => ({ access_token, refresh_token })
+  const parseOauthTokens = ({ access_token, refresh_token }: { access_token: string; refresh_token: string }) => ({
+    access_token, // eslint-disable-line camelcase
+    refresh_token, // eslint-disable-line camelcase
+  })
 
-  const translateAuthClientError = (error) => {
+  const translateAuthClientError = (error: string) => {
     logger.info(`Sign in error description = ${error}`)
 
     if (error.includes('has expired')) return 'Your password has expired.'
@@ -44,7 +55,14 @@ const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
     return 'The username or password you have entered is invalid.'
   }
 
-  const makeTokenRequest = (data, msg) =>
+  interface ErrorData {
+    error_description?: string
+  }
+
+  const getErrorDescription = (error: AxiosError) =>
+    ((error.response && error.response.data) as ErrorData)?.error_description || null
+
+  const makeTokenRequest = (data: string, msg: string) =>
     oauthAxios({ data })
       .then((response) => {
         logger.debug(
@@ -52,11 +70,11 @@ const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
         )
         return parseOauthTokens(response.data)
       })
-      .catch((error) => {
+      .catch((error: AxiosError) => {
         const status = errorStatusCode(error)
-        const errorDesc = (error.response && error.response.data && error.response.data.error_description) || null
+        const errorDesc = getErrorDescription(error)
 
-        if (parseInt(status, 10) < 500 && errorDesc !== null) {
+        if (status < 500 && errorDesc !== null) {
           logger.info(`${msg} ${error.config.method} ${error.config.url} ${status} ${errorDesc}`)
 
           throw AuthClientError(translateAuthClientError(errorDesc))
@@ -70,7 +88,7 @@ const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
    * Perform OAuth token refresh, returning the tokens to the caller. See scopedStore.run.
    * @returns A Promise that resolves when token refresh has succeeded and the OAuth tokens have been returned.
    */
-  const refresh = (refreshToken) =>
+  const refresh = (refreshToken: string) =>
     makeTokenRequest(querystring.stringify({ refresh_token: refreshToken, grant_type: 'refresh_token' }), 'refresh:')
 
   return {
@@ -79,5 +97,3 @@ const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
     oauthAxios,
   }
 }
-
-module.exports = { oauthApiFactory, AuthClientError, AuthClientErrorName, apiClientCredentials }

--- a/backend/apis.js
+++ b/backend/apis.js
@@ -5,13 +5,11 @@ const { manageUsersApiFactory } = require('./api/manageUsersApi')
 const { tokenVerificationApiFactory } = require('./api/tokenVerificationApi')
 const { nomisUsersAndRolesFactory } = require('./api/nomisUsersAndRolesApi')
 
-const oauthApi = oauthApiFactory(
-  clientFactory({
-    baseUrl: config.apis.hmppsAuth.url,
-    timeout: config.apis.hmppsAuth.timeoutSeconds * 1000,
-  }),
-  { ...config.apis.hmppsAuth },
-)
+const oauthApi = oauthApiFactory({
+  apiClientId: config.apis.hmppsAuth.apiClientId,
+  apiClientSecret: config.apis.hmppsAuth.apiClientSecret,
+  url: config.apis.hmppsAuth.url,
+})
 
 const manageUsersApi = manageUsersApiFactory(
   clientFactory({


### PR DESCRIPTION
Refactor oauthApi and tests plus dependent files

**Note - a point to highlight:**
This PR removes `client` as a parameter in `oauthApiFactory` - (`oauthApi.ts - line 21) 
`client` was an `oauthEnabledClient` but was apparently unused
Removing it decouples this file from oauthEnabledClient and allows us to refactor oauthApi and oauthEnabledClient separately.
Probably just an artefact but it is a bit of a mystery so I've highlighted the change

