### PR TITLE
Fix wrap-around text on tags

### DIFF
--- a/sass/_govuk-overrides.scss
+++ b/sass/_govuk-overrides.scss
@@ -26,3 +26,7 @@
   cursor: pointer;
   color: $govuk-link-colour;
 }
+
+.govuk-tag {
+  max-width: 200px;
+}


### PR DESCRIPTION
adds 40px to max-width on govuk-tags 

This accommodates the status EXPIRED_LOCKED user status that was wrapping badly after a change to the standard GOV.UK font