### PR TITLE
HAAR-2658: Increase manage users api response timeout to allow for longer response for user download

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -79,7 +79,7 @@ export default {
     manageUsers: {
       url: get('MANAGE_USERS_API_ENDPOINT_URL', 'http://localhost:9091', requiredInProduction),
       timeout: {
-        response: Number(get('MANAGE_USERS_API_ENDPOINT_TIMEOUT_RESPONSE', 60000)),
+        response: Number(get('MANAGE_USERS_API_ENDPOINT_TIMEOUT_RESPONSE', 180000)),
         deadline: Number(get('MANAGE_USERS_API_ENDPOINT_TIMEOUT_DEADLINE', 60000)),
       },
       agent: new AgentConfig(Number(get('MANAGE_USERS_API_ENDPOINT_TIMEOUT_RESPONSE', 60000))),


### PR DESCRIPTION
Have just updated the timeout for the existing manage users api configuration to line up with the nomis download users api timeout - as it was already 60 seconds so less of a jump going to 3 minutes compared to the api changes to warrant a separate config for just the download endpoint, but if the feeling is we should keep it separate here too then I can do that too