### PR TITLE
fix incorrect field name in create job request body

### DIFF
--- a/backend/api/oauthEnabledClient.ts
+++ b/backend/api/oauthEnabledClient.ts
@@ -120,7 +120,7 @@ export const oauthEnabledClientFactory = (params: ClientFactoryParams): OAuthEna
       const req = superagent
         .post(remoteUrl + path)
         .set(getHeaders(context))
-        .attach(multipart.fieldName, fs.createReadStream(multipart.filepath), multipart.filepath)
+        .attach(multipart.fieldName, fs.createReadStream(multipart.filepath), multipart.filename)
         .attach(body.fieldName, Buffer.from(JSON.stringify(body.body)), {
           filename: body.filename,
           contentType: 'application/json',

--- a/integration-tests/mockApis/manageusers.js
+++ b/integration-tests/mockApis/manageusers.js
@@ -1295,7 +1295,7 @@ module.exports = {
           },
         ],
         bodyPatterns: [
-          { contains: 'Content-Type: application/octet-stream' },
+          { contains: 'Content-Type: application/json' },
           { contains: 'userId\nX123456\nY999999' },
           { contains: 'Content-Disposition: form-data; name="bulkJobDetails"; filename="bulkJobDetails.json' },
           { contains: 'Content-Type: application/json' },


### PR DESCRIPTION
Fix defect in submit request body logic - was not setting the filename as `.json` / `content-type` as `application/json` so was being rejected by the server