### PR TITLE
update controller to use in mem storage for csv file

### DIFF
--- a/backend/@types/express/index.d.ts
+++ b/backend/@types/express/index.d.ts
@@ -14,7 +14,7 @@ declare module 'express-session' {
       roles: string[]
       usersFile: {
         filename: string
-        path: string
+        data: Buffer
       }
     }
   }

--- a/backend/api/manageUsersApi.test.ts
+++ b/backend/api/manageUsersApi.test.ts
@@ -1,5 +1,7 @@
 import nock from 'nock'
 import superagent from 'superagent'
+import fs from 'fs'
+import path from 'path'
 import { ManageUsersApi, manageUsersApiFactory } from './manageUsersApi'
 import { OAuthEnabledClient } from './oauthEnabledClient'
 import {
@@ -1152,12 +1154,13 @@ describe('manageUsersApiImport tests', () => {
     })
 
     it('return expected response', () => {
+      const buffer = fs.readFileSync(path.join(__dirname, '..', '..', 'fixtures', 'bulkUserRoles', 'valid-users.csv'))
       const actual = manageUsersApi.bulkUserRolesAdditions(
         context,
         { jiraReference: '666', roles: ['ROLE_1', 'ROLE_2'] },
         {
-          path: '/tmp/1234567890/users.csv',
-          filename: 'users.csv',
+          data: buffer,
+          filename: 'valid-users.csv',
         },
       )
 
@@ -1166,14 +1169,16 @@ describe('manageUsersApiImport tests', () => {
         context,
         '/bulk-jobs/user-role-additions',
         {
-          fieldName: 'userCsv',
-          filename: 'users.csv',
-          filepath: '/tmp/1234567890/users.csv',
-        },
-        {
           fieldName: 'bulkJobDetails',
           filename: 'bulkJobDetails.json',
-          body: { jiraReference: '666', roles: ['ROLE_1', 'ROLE_2'] },
+          data: Buffer.from(JSON.stringify({ jiraReference: '666', roles: ['ROLE_1', 'ROLE_2'] })),
+          contentType: 'application/json',
+        },
+        {
+          fieldName: 'userCsv',
+          filename: 'valid-users.csv',
+          data: buffer,
+          contentType: 'text/csv',
         },
       )
       expect(actual).toEqual(response)

--- a/backend/api/manageUsersApi.ts
+++ b/backend/api/manageUsersApi.ts
@@ -7,7 +7,6 @@ import { MultiPartValue, OAuthEnabledClient } from './oauthEnabledClient'
 import * as contextProperties from '../contextProperties'
 import {
   BulkUserRoleAdditionsRequest,
-  BulkUserRoleAdditionsResponse,
   ChildGroup,
   CreateChildGroupRequest,
   CreateEmailDomainRequest,

--- a/backend/api/manageUsersApi.ts
+++ b/backend/api/manageUsersApi.ts
@@ -3,7 +3,7 @@ import * as querystring from 'querystring'
 
 import { Context } from '../interfaces/context'
 import { PagedList } from '../interfaces/pagedList'
-import { MultipartBody, MultipartFile, OAuthEnabledClient } from './oauthEnabledClient'
+import { MultiPartValue, OAuthEnabledClient } from './oauthEnabledClient'
 import * as contextProperties from '../contextProperties'
 import {
   BulkUserRoleAdditionsRequest,
@@ -43,7 +43,7 @@ import {
 
 type FileInfo = {
   filename: string
-  path: string
+  data: Buffer
 }
 
 const processPageResponse =
@@ -65,8 +65,8 @@ export const manageUsersApiFactory = (oauthEnabledClient: OAuthEnabledClient) =>
     oauthEnabledClient.put(context, path, body).then((response) => response.body)
   const del = (context: Context, path: string) =>
     oauthEnabledClient.del(context, path).then((response) => response.body)
-  const postMultipartData = (context: Context, path: string, multipart: MultipartFile, body: MultipartBody) =>
-    oauthEnabledClient.postMultipartData(context, path, multipart, body).then((response) => response.body)
+  const postMultipartData = (context: Context, path: string, ...multiparts: MultiPartValue[]) =>
+    oauthEnabledClient.postMultipartData(context, path, ...multiparts).then((response) => response.body)
 
   const getNotificationBannerMessage = (context: Context, notificationType: string): Promise<NotificationMessage> =>
     get(context, `/notification/banner/${notificationType}`)
@@ -360,21 +360,23 @@ export const manageUsersApiFactory = (oauthEnabledClient: OAuthEnabledClient) =>
     context: Context,
     bulkUserRoleAdditionsRequest: BulkUserRoleAdditionsRequest,
     fileInfo: FileInfo,
-  ): Promise<BulkUserRoleAdditionsResponse> =>
-    postMultipartData(
-      context,
-      '/bulk-jobs/user-role-additions',
-      {
-        fieldName: 'userCsv',
-        filename: fileInfo.filename,
-        filepath: fileInfo.path,
-      },
-      {
-        fieldName: 'bulkJobDetails',
-        filename: 'bulkJobDetails.json',
-        body: bulkUserRoleAdditionsRequest,
-      },
-    )
+  ) => {
+    const jsonBody: MultiPartValue = {
+      fieldName: 'bulkJobDetails',
+      filename: 'bulkJobDetails.json',
+      data: Buffer.from(JSON.stringify(bulkUserRoleAdditionsRequest)),
+      contentType: 'application/json',
+    }
+
+    const csvFile: MultiPartValue = {
+      fieldName: 'userCsv',
+      filename: fileInfo.filename,
+      data: Buffer.from(fileInfo.data),
+      contentType: 'text/csv',
+    }
+
+    return postMultipartData(context, '/bulk-jobs/user-role-additions', jsonBody, csvFile)
+  }
 
   return {
     addDpsUserRoles,

--- a/backend/api/oauthEnabledClient.test.ts
+++ b/backend/api/oauthEnabledClient.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import path from 'path'
+import fs from 'fs'
 import * as contextProperties from '../contextProperties'
 import { oauthEnabledClientFactory } from './oauthEnabledClient'
 import { Context } from '../interfaces/context'
@@ -175,12 +176,14 @@ describe('Test clients built by oauthEnabledClient', () => {
         {
           fieldName: 'userCsv',
           filename: 'valid-users.csv',
-          filepath: path.join(__dirname, '..', '..', 'fixtures', 'bulkUserRoles', 'valid-users.csv'),
+          data: fs.readFileSync(path.join(__dirname, '..', '..', 'fixtures', 'bulkUserRoles', 'valid-users.csv')),
+          contentType: 'text/csv',
         },
         {
           fieldName: 'bulkJobDetails',
           filename: 'bulkJobDetails.json',
-          body: { jiraReference: '1234567890', roles: ['ROLE_1', 'ROLE_2'] },
+          data: Buffer.from(JSON.stringify({ jiraReference: '1234567890', roles: ['ROLE_1', 'ROLE_2'] })),
+          contentType: 'application/json',
         },
       )
 
@@ -195,29 +198,6 @@ describe('Test clients built by oauthEnabledClient', () => {
       )
       expect(capturedBody).toContain('Content-Type: application/json')
       expect(capturedBody).toContain(JSON.stringify({ jiraReference: '1234567890', roles: ['ROLE_1', 'ROLE_2'] }))
-    })
-
-    it('should reject with error if file not found', async () => {
-      const scope = captureRequestBody('666')
-
-      await expect(
-        client.postMultipartData(
-          context,
-          '/bulk-jobs/user-role-additions',
-          {
-            fieldName: 'userCsv',
-            filename: 'valid-users.csv',
-            filepath: '/madeup/path',
-          },
-          {
-            fieldName: 'bulkJobDetails',
-            filename: 'bulkJobDetails.json',
-            body: { jiraReference: '1234567890', roles: ['ROLE_1', 'ROLE_2'] },
-          },
-        ),
-      ).rejects.toThrow('ENOENT')
-
-      expect(scope.isDone()).toBe(false)
     })
   })
 })

--- a/backend/api/oauthEnabledClient.ts
+++ b/backend/api/oauthEnabledClient.ts
@@ -10,16 +10,11 @@ export interface ClientFactoryParams {
   timeout: number
 }
 
-export interface MultipartFile {
+export interface MultiPartValue {
   fieldName: string
   filename: string
-  filepath: string
-}
-
-export interface MultipartBody {
-  fieldName: string
-  filename: string
-  body: unknown
+  data: Buffer
+  contentType: string
 }
 
 export interface OAuthEnabledClient {
@@ -27,12 +22,7 @@ export interface OAuthEnabledClient {
   post: (context: Context, path: string, body?: unknown) => Promise<superagent.Response>
   put: (context: Context, path: string, body: unknown) => Promise<superagent.Response>
   del: (context: Context, path: string, body?: unknown) => Promise<superagent.Response>
-  postMultipartData: (
-    context: Context,
-    path: string,
-    multipart: MultipartFile,
-    body: MultipartBody,
-  ) => Promise<superagent.Response>
+  postMultipartData: (context: Context, path: string, ...multipart: MultiPartValue[]) => Promise<superagent.Response>
 }
 
 const resultLogger = (result: superagent.Response) => {
@@ -115,16 +105,16 @@ export const oauthEnabledClientFactory = (params: ClientFactoryParams): OAuthEna
         })
     })
 
-  const postMultipartData = (context: Context, path: string, multipart: MultipartFile, body: MultipartBody) =>
+  const postMultipartData = (context: Context, path: string, ...multiparts: MultiPartValue[]) =>
     new Promise<superagent.Response>((resolve, reject) => {
-      const req = superagent
-        .post(remoteUrl + path)
-        .set(getHeaders(context))
-        .attach(multipart.fieldName, fs.createReadStream(multipart.filepath), multipart.filename)
-        .attach(body.fieldName, Buffer.from(JSON.stringify(body.body)), {
-          filename: body.filename,
-          contentType: 'application/json',
+      const req = superagent.post(remoteUrl + path).set(getHeaders(context))
+
+      multiparts?.forEach((p) => {
+        req.attach(p.fieldName, p.data, {
+          filename: p.filename,
+          contentType: p.contentType,
         })
+      })
 
       req.end((error, response: superagent.Response) => {
         if (error) reject(errorLogger(error))

--- a/backend/api/oauthEnabledClient.ts
+++ b/backend/api/oauthEnabledClient.ts
@@ -1,6 +1,5 @@
 import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
-import fs from 'fs'
 import logger from '../../logger'
 import { getHeaders } from './axios-config-decorators'
 import { Context } from '../interfaces/context'

--- a/backend/controllers/createBulkUserRolesRequests.js
+++ b/backend/controllers/createBulkUserRolesRequests.js
@@ -1,6 +1,7 @@
 const fsAsync = require('fs/promises')
 const fs = require('fs')
 const csv = require('csv-parser')
+const { Readable } = require('stream')
 const config = require('../config').default
 const log = require('../log')
 
@@ -121,7 +122,7 @@ const createBulkUserRolesRequestsFactory = (getSearchableRolesApi, bulkUserRoles
     }
 
     req.session.bulkUserRolesRequest.totalNumberOfUsers = totalNumberOfUsers
-    req.session.bulkUserRolesRequest.usersFile = { filename: file.originalname, path: file.path }
+    req.session.bulkUserRolesRequest.usersFile = { filename: file.originalname, data: file.buffer }
     res.redirect('/change-roles-in-bulk/summary')
   }
 
@@ -154,10 +155,7 @@ const createBulkUserRolesRequestsFactory = (getSearchableRolesApi, bulkUserRoles
       jiraReference: bulkUserRolesRequest.jiraReference,
       roles: bulkUserRolesRequest.roles,
     }
-    const fileInfo = {
-      path: bulkUserRolesRequest.usersFile.path,
-      filename: bulkUserRolesRequest.usersFile.filename,
-    }
+    const fileInfo = bulkUserRolesRequest.usersFile
 
     try {
       await bulkUserRolesAdditions(res.locals, bulkUserRolesAdditionsRequest, fileInfo)
@@ -202,7 +200,10 @@ const createBulkUserRolesRequestsFactory = (getSearchableRolesApi, bulkUserRoles
       let userCount = 0
       let hasValidationError = false
 
-      fs.createReadStream(file.path)
+      const { buffer } = file
+      const fileStream = Readable.from(buffer)
+
+      fileStream
         .pipe(csv())
         .on('headers', (headers) => {
           if (hasValidationError) return
@@ -265,7 +266,7 @@ const createBulkUserRolesRequestsFactory = (getSearchableRolesApi, bulkUserRoles
     if (!details?.roles || details?.roles?.length === 0) {
       errors.push({ text: 'Roles is required', href: '#change-roles-ref' })
     }
-    if (!details?.usersFile?.path || details?.usersFile?.path === 0) {
+    if (!details?.usersFile?.data || details?.usersFile?.data?.length === 0) {
       errors.push({ text: 'Upload file is required', href: '#change-users-ref' })
     }
 

--- a/backend/controllers/createBulkUserRolesRequests.js
+++ b/backend/controllers/createBulkUserRolesRequests.js
@@ -1,5 +1,4 @@
 const fsAsync = require('fs/promises')
-const fs = require('fs')
 const csv = require('csv-parser')
 const { Readable } = require('stream')
 const config = require('../config').default

--- a/backend/controllers/createBulkUserRolesRequests.test.js
+++ b/backend/controllers/createBulkUserRolesRequests.test.js
@@ -1,5 +1,6 @@
 const fsPromises = require('fs/promises')
 const path = require('path')
+const fs = require('fs')
 const { createBulkUserRolesRequestsFactory } = require('./createBulkUserRolesRequests')
 
 describe('change user roles in bulk', () => {
@@ -97,16 +98,25 @@ describe('change user roles in bulk', () => {
     })
 
     it('submitting valid Jira Reference when all other fields are present redirects to summary page', async () => {
+      const filepath = resolveFilePath('valid-users.csv')
+      const fileData = fs.readFileSync(filepath)
+
       req.session.bulkUserRolesRequest = {
         jiraReference: undefined,
         totalNumberOfUsers: 3,
         roles: ['r1', 'r2', 'r3'],
         usersFile: {
-          filename: 'users.csv',
-          path: '/filepath/here',
+          filename: 'valid-users.csv',
+          data: fileData,
         },
       }
+
       req.body = { jiraReference: '12345' }
+      req.file = {
+        originalFilename: 'valid-users.csv',
+        buffer: fileData,
+      }
+
       await bulkUserRolesController.postJiraReference(req, resp)
 
       expect(redirect).toHaveBeenCalledWith('/change-roles-in-bulk/summary')
@@ -117,8 +127,8 @@ describe('change user roles in bulk', () => {
       expect(req.session.bulkUserRolesRequest.totalNumberOfUsers).toEqual(3)
       expect(req.session.bulkUserRolesRequest.roles).toEqual(['r1', 'r2', 'r3'])
       expect(req.session.bulkUserRolesRequest.usersFile).toBeDefined()
-      expect(req.session.bulkUserRolesRequest.usersFile.filename).toEqual('users.csv')
-      expect(req.session.bulkUserRolesRequest.usersFile.path).toEqual('/filepath/here')
+      expect(req.session.bulkUserRolesRequest.usersFile.filename).toEqual('valid-users.csv')
+      expect(req.session.bulkUserRolesRequest.usersFile.data).toEqual(fileData)
     })
 
     test.each([
@@ -142,6 +152,7 @@ describe('change user roles in bulk', () => {
       async (sessionValue) => {
         req.session.bulkUserRolesRequest = sessionValue
         req.body = { jiraReference: '12345' }
+
         await bulkUserRolesController.postJiraReference(req, resp)
 
         expect(redirect).toHaveBeenCalledWith('/change-roles-in-bulk/select-roles')
@@ -310,11 +321,14 @@ describe('change user roles in bulk', () => {
     })
 
     it('redirects to summary page when valid roles selected and all inputs have been provided', async () => {
+      const filepath = resolveFilePath('valid-users.csv')
+      const fileData = fs.readFileSync(filepath)
+
       getSearchableRolesApi.mockResolvedValue(rolesList)
 
       req.session.bulkUserRolesRequest.jiraReference = '12345'
       req.session.bulkUserRolesRequest.totalNumberOfUsers = 3
-      req.session.bulkUserRolesRequest.usersFile = { filename: 'file1.csv', path: '/tmp/file1.csv' }
+      req.session.bulkUserRolesRequest.usersFile = { filename: 'valid-users.csv', data: fileData }
 
       const selectedRoles = ['ROLE_ONE']
       req.body = { selectedRoles }
@@ -327,7 +341,7 @@ describe('change user roles in bulk', () => {
       expect(req.session.bulkUserRolesRequest.totalNumberOfUsers).toEqual(3)
       expect(req.session.bulkUserRolesRequest.roles).toEqual(selectedRoles)
       expect(req.session.bulkUserRolesRequest.usersFile).toBeDefined()
-      expect(req.session.bulkUserRolesRequest.usersFile).toEqual({ filename: 'file1.csv', path: '/tmp/file1.csv' })
+      expect(req.session.bulkUserRolesRequest.usersFile).toEqual({ filename: 'valid-users.csv', data: fileData })
     })
 
     it('post select roles populates req.session.bulkUserRolesRequest if not present', async () => {
@@ -364,6 +378,9 @@ describe('change user roles in bulk', () => {
   })
 
   describe('Post users csv', () => {
+    const fileData = fs.readFileSync(resolveFilePath('valid-users.csv'))
+    const validUsersFile = { filename: 'valid-users.csv', data: fileData }
+
     it('renders upload users csv page when no file uploaded', async () => {
       req.file = undefined
       req.csrfToken = getCsrfToken.mockReturnValue('AAA111BBB222CCC333')
@@ -380,7 +397,7 @@ describe('change user roles in bulk', () => {
     test.each([
       {
         desc: 'non csv',
-        file: { originalname: 'file.html', path: resolveFilePath('users-html.html') },
+        file: { originalname: 'file.html', path: resolveFilePath('users-html-file.html') },
         expectedError: 'csv file is required',
       },
       {
@@ -404,7 +421,11 @@ describe('change user roles in bulk', () => {
         expectedError: 'each row must contain a non null non empty userId',
       },
     ])('renders upload users csv page when invalid file uploaded: $desc', async (testCase) => {
-      req.file = testCase.file
+      const uploadedFileData = fs.readFileSync(testCase.file.path)
+      req.file = {
+        originalname: testCase.file.originalname,
+        buffer: uploadedFileData,
+      }
       req.csrfToken = getCsrfToken.mockReturnValue('AAA111BBB222CCC333')
 
       await bulkUserRolesController.postUserCsvUpload(req, resp)
@@ -416,7 +437,7 @@ describe('change user roles in bulk', () => {
     })
 
     it('renders summary page when valid file uploaded', async () => {
-      req.file = { originalname: 'file.csv', path: resolveFilePath('valid-users.csv') }
+      req.file = { originalname: 'valid-users.csv', buffer: fileData }
       req.csrfToken = getCsrfToken.mockReturnValue('AAA111BBB222CCC333')
 
       await bulkUserRolesController.postUserCsvUpload(req, resp)
@@ -424,15 +445,12 @@ describe('change user roles in bulk', () => {
       expect(redirect).toHaveBeenCalledWith('/change-roles-in-bulk/summary')
 
       expect(req.session.bulkUserRolesRequest.totalNumberOfUsers).toEqual(2)
-      expect(req.session.bulkUserRolesRequest.usersFile).toEqual({
-        filename: 'file.csv',
-        path: resolveFilePath('valid-users.csv'),
-      })
+      expect(req.session.bulkUserRolesRequest.usersFile).toEqual(validUsersFile)
     })
 
     it('post users file populates req.session.bulkUserRolesRequest if not present', async () => {
       req.session.bulkUserRolesRequest = undefined
-      req.file = { originalname: 'file.csv', path: resolveFilePath('valid-users.csv') }
+      req.file = { originalname: 'valid-users.csv', buffer: fileData }
       req.csrfToken = getCsrfToken.mockReturnValue('AAA111BBB222CCC333')
 
       await bulkUserRolesController.postUserCsvUpload(req, resp)
@@ -441,20 +459,19 @@ describe('change user roles in bulk', () => {
 
       expect(req.session.bulkUserRolesRequest).toBeDefined()
       expect(req.session.bulkUserRolesRequest.totalNumberOfUsers).toEqual(2)
-      expect(req.session.bulkUserRolesRequest.usersFile).toEqual({
-        filename: 'file.csv',
-        path: resolveFilePath('valid-users.csv'),
-      })
+      expect(req.session.bulkUserRolesRequest.usersFile).toEqual(validUsersFile)
     })
   })
 
   describe('Get summary', () => {
+    const fileData = fs.readFileSync(resolveFilePath('valid-users.csv'))
+
     it('renders create bulk user roles request summary', async () => {
       const bulkUserRoles = {
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'file.csv', path: resolveFilePath('file.csv') },
+        usersFile: { filename: 'valid-users.csv', data: fileData },
       }
       req.session.bulkUserRolesRequest = bulkUserRoles
 
@@ -465,7 +482,7 @@ describe('change user roles in bulk', () => {
           jiraReference: '12345',
           requestedBy: 'Robert Bobby',
           roles: ['ROLE_1', 'ROLE_2'],
-          uploadFile: 'file.csv',
+          uploadFile: 'valid-users.csv',
           totalAssignments: 6,
           totalNumberOfUsers: 3,
         },
@@ -528,6 +545,9 @@ describe('change user roles in bulk', () => {
   })
 
   describe('Submit bulk user roles request summary', () => {
+    const fileData = fs.readFileSync(resolveFilePath('valid-users.csv'))
+    const validUserFile = { filename: 'valid-users.csv', data: fileData }
+
     test.each([
       {
         desc: 'jira reference undefined',
@@ -651,7 +671,7 @@ describe('change user roles in bulk', () => {
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'users.csv', path: '/tmp/users.csv' },
+        usersFile: validUserFile,
       }
 
       await bulkUserRolesController.postSubmitBulkUserRolesRequest(req, resp)
@@ -660,7 +680,7 @@ describe('change user roles in bulk', () => {
       expect(bulkUserRolesAdditions).toHaveBeenCalledWith(
         resp.locals,
         { jiraReference: '12345', roles: ['ROLE_1', 'ROLE_2'] },
-        { filename: 'users.csv', path: '/tmp/users.csv' },
+        validUserFile,
       )
       expect(req.session.bulkUserRolesRequest).toBeUndefined()
     })
@@ -670,14 +690,13 @@ describe('change user roles in bulk', () => {
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'users.csv', path: '/tmp/users.csv' },
+        usersFile: { filename: 'valid-users.csv', data: fileData },
       }
 
       await bulkUserRolesController.postSubmitBulkUserRolesRequest(req, resp)
 
       expect(render).toHaveBeenCalledWith('createBulkUserRolesConfirmation.njk', { jiraReference: '12345' })
       expect(req.session.bulkUserRolesRequest).toBeUndefined()
-      expect(spyUnlink).toHaveBeenNthCalledWith(1, '/tmp/users.csv')
     })
 
     it('should not remove request details from session if bulkUserRolesAdditions fails', async () => {
@@ -687,7 +706,7 @@ describe('change user roles in bulk', () => {
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'users.csv', path: '/tmp/users.csv' },
+        usersFile: { filename: 'valid-users.csv', data: fileData },
       }
 
       await bulkUserRolesController.postSubmitBulkUserRolesRequest(req, resp)
@@ -700,21 +719,20 @@ describe('change user roles in bulk', () => {
           totalNumberOfUsers: 3,
           totalAssignments: 6,
           roles: ['ROLE_1', 'ROLE_2'],
-          uploadFile: 'users.csv',
+          uploadFile: 'valid-users.csv',
         },
       })
       expect(bulkUserRolesAdditions).toHaveBeenCalledWith(
         resp.locals,
         { jiraReference: '12345', roles: ['ROLE_1', 'ROLE_2'] },
-        { filename: 'users.csv', path: '/tmp/users.csv' },
+        { filename: 'valid-users.csv', data: fileData },
       )
 
-      expect(spyUnlink).not.toHaveBeenCalled()
       expect(req.session.bulkUserRolesRequest).toEqual({
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'users.csv', path: '/tmp/users.csv' },
+        usersFile: { filename: 'valid-users.csv', data: fileData },
       })
     })
 
@@ -733,7 +751,7 @@ describe('change user roles in bulk', () => {
         jiraReference: '12345',
         totalNumberOfUsers: 3,
         roles: ['ROLE_1', 'ROLE_2'],
-        usersFile: { filename: 'users.csv', path: '/tmp/users.csv' },
+        usersFile: { filename: 'valid-users.csv', data: fileData },
       }
 
       bulkUserRolesAdditions.mockRejectedValue(Error('status 500!!'))
@@ -748,7 +766,7 @@ describe('change user roles in bulk', () => {
           totalNumberOfUsers: 3,
           totalAssignments: 6,
           roles: ['ROLE_1', 'ROLE_2'],
-          uploadFile: 'users.csv',
+          uploadFile: 'valid-users.csv',
         },
       })
     })

--- a/backend/middleware/authorisationMiddleware.test.ts
+++ b/backend/middleware/authorisationMiddleware.test.ts
@@ -309,4 +309,25 @@ describe('authorisationMiddleware', () => {
       expect(res.redirect).toHaveBeenCalledWith('/authError')
     })
   })
+
+  describe('Create bulk user roles additions', () => {
+    it('should show correct page when user with correct role tries to access change roles in bulk endpoint', () => {
+      const reqCreateRole = { originalUrl: '/change-roles-in-bulk' } as Request
+      const res = createResWithToken({ authorities: ['ROLE_MANAGE_USER_BULK_JOBS'] })
+
+      authorisationMiddleware([])(reqCreateRole, res, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+    it('should redirect when user without correct role tries to access change roles in bulk  endpoint', () => {
+      const reqDeleteGroup = { originalUrl: '/change-roles-in-bulk' } as Request
+      const res = createResWithToken({ authorities: ['ROLE_WRONG_ROLE'] })
+
+      authorisationMiddleware([])(reqDeleteGroup, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('/authError')
+    })
+  })
 })

--- a/backend/middleware/authorisationMiddleware.ts
+++ b/backend/middleware/authorisationMiddleware.ts
@@ -10,6 +10,7 @@ enum AuthRole {
   ROLES_ADMIN = 'ROLE_ROLES_ADMIN',
   MAINTAIN_EMAIL_DOMAINS = 'ROLE_MAINTAIN_EMAIL_DOMAINS',
   CONTRACT_MANAGER_VIEW_GROUP = 'ROLE_CONTRACT_MANAGER_VIEW_GROUP',
+  MANAGE_USER_BULK_JOBS = 'ROLE_MANAGE_USER_BULK_JOBS',
 }
 
 const authorisationMap = {
@@ -26,6 +27,7 @@ const authorisationMap = {
   '/create-email-domain': [AuthRole.MAINTAIN_EMAIL_DOMAINS],
   '/delete-email-domain': [AuthRole.MAINTAIN_EMAIL_DOMAINS],
   '/crs-group-selection': [AuthRole.CONTRACT_MANAGER_VIEW_GROUP],
+  '/change-roles-in-bulk': [AuthRole.MANAGE_USER_BULK_JOBS],
 }
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {

--- a/backend/middleware/currentUser.js
+++ b/backend/middleware/currentUser.js
@@ -25,7 +25,7 @@ module.exports =
         manageEmailDomains: hasRole(roles, 'MAINTAIN_EMAIL_DOMAINS'),
         manageUserAllowList: hasRole(roles, 'MANAGE_USER_ALLOW_LIST'),
         crsGroupUsersDownload: hasRole(roles, 'CONTRACT_MANAGER_VIEW_GROUP'),
-        bulkUserRolesAdmin: hasRole(roles, 'BULK_USER_ROLES_ADMIN'),
+        bulkUserRolesAdmin: hasRole(roles, 'MANAGE_USER_BULK_JOBS'),
       }
     }
 

--- a/backend/middleware/currentUser.test.js
+++ b/backend/middleware/currentUser.test.js
@@ -339,7 +339,7 @@ describe('Current user', () => {
       crsGroupUsersDownload: false,
       bulkUserRolesAdmin: true,
     })
-  }) //
+  })
 
   it('should set all roles', async () => {
     manageUsersApi.currentRoles.mockReturnValue([

--- a/backend/middleware/currentUser.test.js
+++ b/backend/middleware/currentUser.test.js
@@ -319,7 +319,7 @@ describe('Current user', () => {
   })
 
   it('should set role Bulk User Roles Admin', async () => {
-    manageUsersApi.currentRoles.mockReturnValue([{ roleCode: 'FRED' }, { roleCode: 'BULK_USER_ROLES_ADMIN' }])
+    manageUsersApi.currentRoles.mockReturnValue([{ roleCode: 'FRED' }, { roleCode: 'MANAGE_USER_BULK_JOBS' }])
     const controller = currentUser({ manageUsersApi })
 
     await controller(req, res, () => {})
@@ -339,7 +339,7 @@ describe('Current user', () => {
       crsGroupUsersDownload: false,
       bulkUserRolesAdmin: true,
     })
-  })
+  }) //
 
   it('should set all roles', async () => {
     manageUsersApi.currentRoles.mockReturnValue([
@@ -352,7 +352,7 @@ describe('Current user', () => {
       { roleCode: 'CREATE_USER' },
       { roleCode: 'MANAGE_NOMIS_USER_ACCOUNT' },
       { roleCode: 'MAINTAIN_EMAIL_DOMAINS' },
-      { roleCode: 'BULK_USER_ROLES_ADMIN' },
+      { roleCode: 'MANAGE_USER_BULK_JOBS' },
     ])
     const controller = currentUser({ manageUsersApi })
 

--- a/backend/routes/bulkChangeUserRolesRouter.js
+++ b/backend/routes/bulkChangeUserRolesRouter.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const multer = require('multer')
-const os = require('os')
 const searchApiFactory = require('./searchApiFactory')
 const { createBulkUserRolesRequestsFactory } = require('../controllers/createBulkUserRolesRequests')
 

--- a/backend/routes/bulkChangeUserRolesRouter.js
+++ b/backend/routes/bulkChangeUserRolesRouter.js
@@ -4,9 +4,8 @@ const searchApiFactory = require('./searchApiFactory')
 const { createBulkUserRolesRequestsFactory } = require('../controllers/createBulkUserRolesRequests')
 
 const router = express.Router({ mergeParams: true })
-const storage = multer.memoryStorage()
 const upload = multer({
-  dest: storage,
+  storage: multer.memoryStorage(),
   limits: {
     fileSize: 10 * 1024 * 1024, // 10 MB
     files: 1,

--- a/backend/routes/bulkChangeUserRolesRouter.js
+++ b/backend/routes/bulkChangeUserRolesRouter.js
@@ -5,8 +5,9 @@ const searchApiFactory = require('./searchApiFactory')
 const { createBulkUserRolesRequestsFactory } = require('../controllers/createBulkUserRolesRequests')
 
 const router = express.Router({ mergeParams: true })
+const storage = multer.memoryStorage()
 const upload = multer({
-  dest: os.tmpdir(),
+  dest: storage,
   limits: {
     fileSize: 10 * 1024 * 1024, // 10 MB
     files: 1,

--- a/integration-tests/e2e/bulkuserroles.create.cy.js
+++ b/integration-tests/e2e/bulkuserroles.create.cy.js
@@ -282,7 +282,7 @@ context('Create bulk user roles request: Submit', () => {
 })
 
 function signIn() {
-  cy.task('stubSignIn', { roles: [{ roleCode: 'BULK_USER_ROLES_ADMIN' }] })
+  cy.task('stubSignIn', { roles: [{ roleCode: 'MANAGE_USER_BULK_JOBS' }] })
   cy.signIn()
 }
 

--- a/integration-tests/e2e/menu.cy.js
+++ b/integration-tests/e2e/menu.cy.js
@@ -58,7 +58,7 @@ context('Menu tiles', () => {
   })
 
   it('Shows Change user roles in bulk tile for Bulk user admin user', () => {
-    cy.task('stubSignIn', { roles: [{ roleCode: 'BULK_USER_ROLES_ADMIN' }] })
+    cy.task('stubSignIn', { roles: [{ roleCode: 'MANAGE_USER_BULK_JOBS' }] })
     cy.signIn()
     const menuPage = MenuPage.verifyOnPage()
     menuPage.createBulkUserRoles().should('exist')


### PR DESCRIPTION
1) Fix defect in bulk user role create flow. Previously used temp file to hold uploaded csv file, however this fails when running more than 1 instance of the UI. Fix updates the UI app to hold the csv file as an in memory session value.

2) Added missing auth middleware check for new create bulk user roles flow + tests.

3) Updated the role required to access the new flow to align with the backend api spec.
